### PR TITLE
dev-libs/boost: fixed mingw-w64 build

### DIFF
--- a/dev-libs/boost/boost-1.63.0.ebuild
+++ b/dev-libs/boost/boost-1.63.0.ebuild
@@ -47,6 +47,13 @@ PATCHES=(
 	"${FILESDIR}/${PN}-1.56.0-build-auto_index-tool.patch"
 	"${FILESDIR}/${PN}-1.63.0-fix-python.patch"
 )
+case ${CHOST} in
+	*-mingw*|mingw*|*-winnt*|winnt*)
+	PATCHES+=(
+		"${FILESDIR}/${PN}-1.63.0-serialization-mingw-w64.patch"
+	)
+	;;
+esac
 
 python_bindings_needed() {
 	multilib_is_native_abi && use python
@@ -198,9 +205,19 @@ src_configure() {
 		link=$(usex static-libs shared,static shared)
 	)
 
-	[[ ${CHOST} == *-winnt* ]] && OPTIONS+=(
+	case ${CHOST} in
+	*-mingw*|mingw*|*-winnt*|winnt*)
+		OPTIONS+=(
 			-sNO_BZIP2=1
+			target-os=windows
 		)
+		if use threads; then
+			OPTIONS+=(
+				threadapi=win32
+			)
+		fi
+		;;
+	esac
 }
 
 multilib_src_compile() {

--- a/dev-libs/boost/files/boost-1.63.0-serialization-mingw-w64.patch
+++ b/dev-libs/boost/files/boost-1.63.0-serialization-mingw-w64.patch
@@ -1,0 +1,30 @@
+From aab8477eb1456896bf7311e913fb9b20b5f5e335 Mon Sep 17 00:00:00 2001
+From: xantares <xantares09@hotmail.com>
+Date: Sat, 14 May 2016 16:16:51 +0200
+Subject: [PATCH] Fix undefined reference to codecvt_null<wchar_t>
+
+See https://svn.boost.org/trac/boost/ticket/12205
+---
+ build/Jamfile.v2 | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libs/serialization/build/Jamfile.v2 b/libs/serialization/build/Jamfile.v2
+index 8fd92e6..cb17dd5 100644
+--- a/libs/serialization/build/Jamfile.v2
++++ b/libs/serialization/build/Jamfile.v2
+@@ -80,7 +80,6 @@ SOURCES =
+     xml_iarchive
+     xml_oarchive
+     xml_archive_exception
+-    codecvt_null
+     utf8_codecvt_facet
+     singleton
+ ;
+@@ -93,6 +92,7 @@ WSOURCES =
+     xml_wgrammar
+     xml_wiarchive
+     xml_woarchive
++    codecvt_null
+ ;
+ 
+ lib boost_serialization 


### PR DESCRIPTION
Package-Manager: Portage-2.3.5, Repoman-2.3.2
Closes https://bugs.gentoo.org/show_bug.cgi?id=618890